### PR TITLE
Change aws-sdk requirement

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source "http://rubygems.org"
 
-gem 'aws-sdk', '>= 1.51.0'
+gem 'aws-sdk-v1', '>= 1.51.0'
 
 # Add dependencies to develop your gem here.
 # Include everything needed to run rake, tests, features, etc.

--- a/bin/rds-rotate-db-snapshots
+++ b/bin/rds-rotate-db-snapshots
@@ -1,7 +1,7 @@
 #!/usr/bin/env ruby
 
 require 'rubygems'
-require 'aws-sdk'
+require 'aws-sdk-v1'
 require 'optparse'
 
 $opts = {


### PR DESCRIPTION
Hello,

I had an issue running your script.
The regular aws-sdk version is now 2.1. With this version the namespace changes,
it's not AWS anymore but Aws. So the scripts doesn't work with this version.
By installing aws-sdk-v1, we fix this issue.

Thanks for your work
